### PR TITLE
fillseq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX?=g++
-CXXFLAGS:=-O0 -std=c++11 -g -ggdb
+CXXFLAGS:=-O3 -std=c++11 
 
 
 BIN_DIR:=bin

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 CXX?=g++
-CXXFLAGS:=-O3 -std=c++11 -g 
+CXXFLAGS:=-O0 -std=c++11 -g -ggdb
 
 
 BIN_DIR:=bin
 BUILD_DIR:=build
 
 LD_LIB_FLAGS=-L./src/ -L./
-LD_INC_FLAGS=-I./src/ -I./ -I./$(BUILD_DIR) -I./src/subcommand/
+LD_INC_FLAGS=-I./src/ -I./ -I./src/tinyFA -I./$(BUILD_DIR)
 
-gfak: $(BUILD_DIR)/main.o libgfakluge.a .GFAK_pre-build src/pliib.hpp .GFAK_pre-build
+gfak: $(BUILD_DIR)/main.o libgfakluge.a .GFAK_pre-build src/tinyFA/pliib.hpp src/tinyFA/tinyfa.hpp .GFAK_pre-build
 	+$(CXX) $(CXXFLAGS) -o $@ $< $(LD_LIB_FLAGS) $(LD_INC_FLAGS) -lgfakluge
 
-$(BUILD_DIR)/main.o: src/main.cpp .GFAK_pre-build src/gfakluge.hpp src/pliib.hpp
+$(BUILD_DIR)/main.o: src/main.cpp .GFAK_pre-build src/gfakluge.hpp src/tinyFA/pliib.hpp src/tinyFA/tinyfa.hpp
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_LIB_FLAGS) $(LD_INC_FLAGS) -lgfakluge
 
-libgfakluge.a: $(BUILD_DIR)/gfakluge.o src/pliib.hpp .GFAK_pre-build
+libgfakluge.a: $(BUILD_DIR)/gfakluge.o src/tinyFA/pliib.hpp src/tinyFA/tinyfa.hpp .GFAK_pre-build
 	ar -rs $@ $<
 
-$(BUILD_DIR)/gfakluge.o: src/gfakluge.cpp src/gfakluge.hpp .GFAK_pre-build src/pliib.hpp
+$(BUILD_DIR)/gfakluge.o: src/gfakluge.cpp src/gfakluge.hpp .GFAK_pre-build src/tinyFA/pliib.hpp src/tinyFA/tinyfa.hpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_LIB_FLAGS) $(LD_INC_FLAGS)
 
 .PHONY: clean all

--- a/src/gfakluge.cpp
+++ b/src/gfakluge.cpp
@@ -66,6 +66,31 @@ namespace gfak{
         this->groups[g.id] = g;
     }
 
+    void GFAKluge::fill_sequences(const char* fasta_file){
+
+        TFA::tiny_faidx_t tf;
+        if (TFA::checkFAIndexFileExists(fasta_file)){
+            TFA::parseFAIndex(fasta_file, tf);
+        }
+        else{
+            //cerr << "Creating index for " << fasta_file << "." << endl;
+            TFA::createFAIndex(fasta_file, tf);
+            TFA::writeFAIndex(fasta_file, tf);
+            //cerr << "Index created." << endl;
+        }
+        
+        for (std::map<string, sequence_elem, custom_key>::iterator it = name_to_seq.begin(); it != name_to_seq.end(); it++){
+            if (tf.hasSeqID(it->second.name.c_str())){
+                char* s;
+                TFA::getSequence(tf, it->second.name.c_str(), s);
+                it->second.sequence.assign(s);
+                it->second.length = strlen(s);
+                delete [] s;
+            }
+        }
+    }
+
+
     void GFAKluge::groups_as_paths(){
         for (auto g : groups){
             if (g.second.ordered){

--- a/src/gfakluge.cpp
+++ b/src/gfakluge.cpp
@@ -84,7 +84,7 @@ namespace gfak{
                 char* s;
                 TFA::getSequence(tf, it->second.name.c_str(), s);
                 it->second.sequence.assign(s);
-                it->second.length = strlen(s);
+                //it->second.length = strlen(s);
                 delete [] s;
             }
         }

--- a/src/gfakluge.hpp
+++ b/src/gfakluge.hpp
@@ -11,6 +11,9 @@
 #include <cstdlib>
 #include <iostream>
 #include <bitset>
+#include <sys/stat.h>
+
+#include "tinyfa.hpp"
 #include "pliib.hpp"
 
 namespace gfak{
@@ -444,14 +447,6 @@ namespace gfak{
 
             void groups_as_paths();
 
-            // Minimize memory consumption by converting everything
-            // to GFA2 compatible containers. We can then convert
-            // this if we want to go back to GFA1.
-            //void compact();
-
-
-
-
             /** End GFA2.0. Begin 1.0 / 0.1 **/
 
             void add_contained(std::string seq_name, contained_elem c);
@@ -464,11 +459,14 @@ namespace gfak{
             void add_path(std::string pathname, path_elem path);
             void add_walk(std::string walkname, walk_elem w);
 
+
+            /** Versioning functions **/
             double get_version();
             void set_version(double version);
             void set_version();
             void set_walks(bool ws);
 
+            /** Getter methods for elements, to keep users out of our data structures **/
             std::vector<link_elem> get_links(const sequence_elem& seq);
             std::vector<link_elem> get_links(const std::string& seq_name);
 
@@ -492,6 +490,7 @@ namespace gfak{
             std::map<std::string, std::vector<gap_elem>> get_seq_to_gaps();
             std::map<std::string, group_elem> get_groups();
 
+            /** Convert paths to walks and walks to paths **/
             void paths_as_walks();
             void walks_as_paths();
 
@@ -506,17 +505,20 @@ namespace gfak{
             std::string block_order_string_2();
             void output_to_stream(std::ostream& os, bool output_block_order = false);
 
+            /** Methods for folks that want streaming output. **/
             void write_element(std::ostream& os, const sequence_elem& s);
             void write_element(std::ostream& os, edge_elem e);
             void write_element(std::ostream& os, const fragment_elem& f);
             void write_element(std::ostream& os, const group_elem& g);
             void write_element(std::ostream& os, const gap_elem& g);
+            
             // ID manipulators
             std::tuple<uint64_t, uint64_t, uint64_t, uint64_t, uint64_t> max_ids();
             std::string max_ids_string();
             void re_id(std::tuple<uint64_t, uint64_t, uint64_t, uint64_t, uint64_t>& new_mx);
             void re_id(std::string new_mx_str);
 
+            /** Merge two GFA graphs **/
             void merge(GFAKluge& gg);
 
             /** Assembly stats **/
@@ -529,7 +531,8 @@ namespace gfak{
             // double simple_connectivity() // reports avg edges / sequence
             // double weighted_connectivity() // weight areas of high connectivity higher
             //      behaves kind of like [(N_edges)^2 / (N_seqs)^2 if N_edges > 2]
-
+            
+            void fill_sequences(const char* fasta_file);
 
             private:
             bool use_walks = false;

--- a/src/tinyFA/README.md
+++ b/src/tinyFA/README.md
@@ -1,0 +1,90 @@
+tinyFA
+-----------------
+Parse, index and get random access to FASTA files
+with no extra dependencies.
+
+### Overview
+tinyFA provides a (relatively) fast and highly minimalist header-only library
+for reading FASTA files, especially in the case that you'd like random access
+via their FAI indices. It requires only a modern (GCC4.8 or newer) C++ compiler.
+
+### Build / install
+Make sure both headers are in a path accessible to your code. You can either
+copy them to your include directory, or pass the directory to your compiler
+with ` -I/path/to/tinyFA`.
+
+Then just include both headers in your C++ code and use the TFA namespace:
+
+```
+    #include "tinyFA/tinyfa.hpp"  
+    #include "tinyFA/pliib.hpp"
+
+    using namespace TFA;
+
+```
+
+### Usage
+
+```
+
+#include "tinyfa.hpp"
+#include "pliib.hpp"
+
+
+int main (int argc, char** argv){
+    // usage: ./getseq <fastaFile> <seqName> <start> <end>
+    // Parse a FASTA file and extract a subsequence.
+    // If a FASTA index exists, use it, otherwise,
+    // build one.
+   
+    // The tinyFA faidx struct
+    tiny_faidx_t tf;
+   
+   // Check if an index exists, and create one if not.
+    if (!checkFAIndexFileExists(argv[1])){
+        createFAIndex(argv[1], tf);
+    }
+    else{
+        // Parses an FAI file when passed a FASTA file name.
+        parseFAIndex(argv[1], tf);
+    }
+
+    char* contigName = argv[2];
+    int start = atoi(argv[3]);
+    int end = atoi(argv[4]);
+    char* seq;
+    
+    // Not passing start/end will return the whole contig.
+    getSequence(tf, contigName, seq, start, end);
+    cout << seq << endl;
+
+    // seq gets allocated in getSequence, so you'll want to delete that.
+    delete [] seq;
+
+    return 0;
+}
+```
+
+### Other tools
+tinyFA takes a lot of code and inspiration from the
+excellent [fastahack](https://github.com/ekg/fastahack).
+Fastahack has been extensively used and we recommend it for production environments.
+It differs from fastahack in that:
+
+1. There's no default library setup for Fastahack. This could easily be remedied
+   with some small makefile tweaks.  
+2. tinyFA mostly uses structs and primitive types (rather than STL containers).
+
+
+There's also [htslib](https://github.com/samtools/htslib), but if you want to
+parse a FASTA file you have to build utilities for SAM/BAM/CRAM/VCF, it requires
+zlib, lzma, and lz4 (which are often not up to date / installed by default).
+
+However, htslib can parse files compressed with BGZF; this may be an important
+addition when dealing with large files.
+
+SeqLib and SeqAn are both excellent tools that add to htslib, with the same cons and
+many extra pros.
+
+
+

--- a/src/tinyFA/pliib.hpp
+++ b/src/tinyFA/pliib.hpp
@@ -147,7 +147,7 @@ namespace pliib{
 
     };
 
-    inline vector<string> split(string s, char delim){
+    inline vector<string> split(const string s, const char delim){
     
         vector<string> ret;
         int slen = s.length();
@@ -191,6 +191,96 @@ namespace pliib{
 
         return ret.str();
     }
+
+    /** Returns a string s', which is the substring of s before the
+     * first appearance of 'delim'.
+     * If delim is the first character, returns an empty string. **/
+
+    inline void trim_after_char(char*&s, const int& len, char delim){
+        int d_index = 0;
+        while(  d_index < len && s[d_index] != delim){
+            ++d_index;
+        }
+        char* ret = new char[d_index + 1];
+        ret[d_index] = '\0';
+        if (d_index > 0){
+            memcpy(ret, s, d_index * sizeof(char));
+        }
+        delete [] s;
+        s = ret;
+
+    };
+
+    /** Removes a character 'r' when it is seen at either the start or end of a string
+     *  Returns a new string with all such occurrences of 'r' removed.
+     *  s is destroyed in the process and replaced by a new string.
+     *  Works like python's "strip(char)" function. **/
+    inline void strip(char*& s, const int& len, char r){
+        int start = 0;
+        int end = len - 1;
+        while (start < len && s[start] == r){
+            ++start;
+        }
+        while(end > 0 && s[end] == r){
+            --end;
+        }
+        int rsz = end - start + 1;
+        char* ret = new char[rsz + 1];
+        memcpy(ret, s + start, rsz * sizeof(char));
+        // cerr << ret << endl;
+        ret[rsz] = '\0';
+        delete [] s;
+        s = ret;
+    };
+
+
+    /** Removes a character from within a string **/
+    inline void remove_char(char*& s, const int& len, char r){
+        int write_index = 0;
+        int read_index = 0;
+        for (int i = 0; i < len, read_index < len; ++i){
+            if (s[i] != r){
+                s[write_index] = s[read_index];
+                ++write_index;
+            }
+            ++read_index;
+        }
+        s[write_index] = '\0';
+    };
+
+    /** Removes any null or whitespace characters from within a string
+     *  where whitespace is ' ' or '\t' or '\n'.
+     *  Complexity: linear time in |s| **/
+    inline void remove_nulls_and_whitespace(char*& s, const int& len){
+        int write_index = 0;
+        int read_index = 0;
+        for (int i = 0; i < len, read_index < len; ++i){
+            if (s[i] != '\n' && s[i] != '\t' && s[i] != '\0' && s[i] != ' '){
+                s[write_index] = s[read_index];
+                ++write_index;
+            }
+            ++read_index;
+        }
+        s[write_index] = '\0';
+    };
+
+    inline void paste(const char** splits, const int& numsplits, const int* splitlens, char*& ret){
+
+        int sz = 0;
+        for (int i = 0; i < numsplits; ++i){
+            sz += splitlens[i];
+        }
+        ret = new char[sz + 1];
+        ret[sz] = '\0';
+
+        int r_pos = 0;
+        for (int i = 0; i < numsplits; ++i){
+            for (int j = 0; j < splitlens[i]; ++j){
+                ret[r_pos] = splits[i][j];
+                ++r_pos;
+            }
+        }
+    };
 
     inline string join(vector<string> splits, string glue){
         stringstream ret;

--- a/src/tinyFA/tinyfa.hpp
+++ b/src/tinyFA/tinyfa.hpp
@@ -1,0 +1,318 @@
+#ifndef TINY_FA_HPP
+#define TINY_FA_HPP
+
+#pragma once
+#define _FILE_OFFSET_BITS 64
+#ifdef WIN32
+#define ftell64(a)     _ftelli64(a)
+#define fseek64(a,b,c) _fseeki64(a,b,c)
+typedef __int64 off_type;
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+#define ftell64(a)     ftello(a)
+#define fseek64(a,b,c) fseeko(a,b,c)
+typedef off_t off_type;
+#else
+#define ftell64(a)     ftello(a)
+#define fseek64(a,b,c) fseeko(a,b,c)
+typedef __off64_t off_type;
+#endif
+
+
+
+#include <string>
+#include <sstream>
+#include <ostream>
+#include <cstdio>
+#include <vector>
+#include <fstream>
+#include <unordered_map>
+#include <map>
+#include <cstdint>
+#include <assert.h>
+#include <algorithm>
+#include <sys/stat.h>
+#include "pliib.hpp"
+
+
+namespace TFA{
+
+    // From https://stackoverflow.com/questions/4157687/using-char-as-a-key-in-stdmap
+struct custom_char_comparator
+{
+   bool operator()(char const *a, char const *b) const
+   {
+      return std::strcmp(a, b) < 0;
+   }
+};
+
+
+
+
+
+struct tiny_faidx_entry_t {
+    char* name;
+    int name_len;
+    int32_t line_char_len;
+    int32_t line_byte_len;
+    int64_t seq_len;
+    int64_t raw_len;
+    uint64_t offset;
+    tiny_faidx_entry_t(){
+        line_char_len = -1;
+        line_byte_len = 0;
+        seq_len = 0;
+        raw_len = 0;
+        offset = -1;
+    };
+    tiny_faidx_entry_t(std::vector<std::string> splits){
+        assert(splits.size() == 5);
+        this->name_len = splits[0].length();
+        this->name = new char[this->name_len + 1];
+        memcpy(this->name, splits[0].c_str(), splits[0].length() * sizeof(char));
+        this->seq_len = std::stol(splits[1]);
+        this->offset = std::stoull(splits[2]);
+        this->line_char_len = std::stoi(splits[3]);
+        this->line_byte_len = std::stoi(splits[4]);
+    };
+    // Five columns
+    // seqname  seqlen  offset  line_char_len   line_byte_len
+    std::string to_string(){
+        std::stringstream st;
+        st << name << '\t' << seq_len << '\t' << offset << '\t' << line_char_len << '\t' << line_byte_len << endl;
+        return st.str();
+    };
+    void write_to_stream(std::ostream& os){
+        os << name << '\t' << seq_len << '\t' << offset << '\t' << line_char_len << '\t' << line_byte_len << endl;
+    };
+};
+
+struct custom_faidx_entry_t_comparator
+{
+   bool operator()(tiny_faidx_entry_t const *a, tiny_faidx_entry_t const *b) const
+   {
+      return a->offset < b->offset;
+   }
+};
+
+struct tiny_faidx_t{
+    std::map<char*, tiny_faidx_entry_t*, custom_char_comparator> seq_to_entry;
+    FILE* fasta;
+    void close(){
+        for (auto k : seq_to_entry){
+            delete k.second->name;
+            delete k.second;
+        }
+    };
+
+    void add(tiny_faidx_entry_t* entry){
+        seq_to_entry[entry->name] = entry;
+    };
+    ~tiny_faidx_t(){
+        close();
+    };
+
+    bool hasSeqID(const char* s) const {
+        return (seq_to_entry.count( (char*) s) != 0);
+    };
+
+    void get(const char* seqname, tiny_faidx_entry_t*& entry) const {
+        entry = seq_to_entry.at((char*) seqname);
+    };
+
+    void write(ostream& os) const {
+        std::vector<tiny_faidx_entry_t*> sorted_entries;
+        for (auto x : seq_to_entry){
+                sorted_entries.push_back(x.second);
+        }
+        std::sort(sorted_entries.begin(), sorted_entries.end(), custom_faidx_entry_t_comparator());
+        for (auto x : sorted_entries){
+            x->write_to_stream(os);
+        }
+    };
+
+    void write(const char* filename) const{
+        std::ofstream ofi;
+        ofi.open(filename);
+        if (ofi.good()){
+            write(ofi);
+        }
+
+    };
+
+} ;
+
+
+// typedef struct {
+//     std::unordered_map<char*, char*, custom_char_comparator> name_to_seq;
+
+//     tiny_fasta_map_t(){
+
+//     }
+
+//     tiny_fasta_map_t(const char* filename){
+
+//     }
+
+//     void get(const char* name, char*&s){
+//         if (name_to_seq.count(name) != 0){
+//             s = name_to_seq[name];
+//         }
+//     };
+
+//     void put(const char* name, const char* s){
+//         name_to_seq[name] = s;
+//     }
+// } tiny_fasta_map_t;
+
+
+// inline void parseFasta(const char* filename, tiny_faidx_t& fai, tiny_fasta_map_t& fam){
+
+// };
+
+inline void createFAIndex(const char* fastaName, tiny_faidx_t& fai){
+    
+    uint64_t line_number = 0;
+    int32_t line_length = 0;
+    uint64_t offset = 0;
+    
+    std::string line;
+
+    std::ifstream faFile;
+    faFile.open(fastaName);
+
+    tiny_faidx_entry_t* entry = new tiny_faidx_entry_t();
+
+    if (faFile.is_open()){
+        while(std::getline(faFile, line)){
+            ++line_number;
+            line_length = line.length();
+            if (line[0] == '>' || line[0] == '@'){
+                // This is a valid fasta name line
+                // Start a new entry and begin filling it.
+                if (entry->name_len != 0){
+                    fai.add(entry);
+                    entry = new tiny_faidx_entry_t();
+                }
+                line = line.substr(1, line_length);
+                char* name = new char[line_length];
+                std::strcpy(name, line.c_str());
+                pliib::strip(name, line_length - 1, ' ');
+                pliib::trim_after_char(name, strlen(name), ' ');
+                //cerr << name << endl;
+                entry->name_len = std::strlen(name);
+                entry->name = new char[entry->name_len];
+                std::strcpy(entry->name, name);
+
+            }
+            else if (line[0] == '+'){
+                std::getline(faFile, line);
+                line_length = line.length();
+                offset += line_length + 1;
+                std::getline(faFile, line);
+                line_length = line.length();
+                offset += line_length + 1;
+            }
+            else{
+                if (entry->offset == -1){
+                    entry->line_char_len = line_length;
+                    entry->line_byte_len = line_length + 1;
+                    entry->offset = offset;
+                }
+
+                entry->seq_len += line_length;
+                entry->raw_len += line_length + 1;
+            }
+            offset += line_length + 1;
+        }
+        if (entry->seq_len >= 0){
+            fai.add(entry);
+        }
+    }
+};
+
+inline void writeFAIndex(const char* fastaName, const tiny_faidx_t& fai){
+    // Create index outfile with the correct name
+    std::string fn(fastaName);
+    fn = fn + ".fai";
+    std::ofstream ofi(fn.c_str());
+    if (ofi.good()){
+        fai.write(ofi);
+    }
+};
+
+inline bool checkFAIndexFileExists(const char* fastaName){
+    struct stat statFileInfo; 
+    string indexFileName(fastaName);
+    indexFileName = indexFileName + ".fai"; 
+    return stat(indexFileName.c_str(), &statFileInfo) == 0;
+};
+
+inline char* indexFileName(const char* fastaName){
+    int len = strlen(fastaName);
+    static const char* file_ext = ".fai";
+    char* ret = new char[len + 5];
+    ret[len + 4] = '\0';
+    strcpy(ret, fastaName);
+    strcpy(ret + len, file_ext);
+    return ret;
+};
+
+inline void parseFAIndex(const char* fastaFileName, tiny_faidx_t& fai){
+    std::ifstream ifi;
+    char* ifn = indexFileName(fastaFileName);
+    ifi.open((const char*) ifn);
+
+    if (!(fai.fasta = fopen(fastaFileName, "r"))){
+        cerr << "Error: couldn't open fasta file " << fastaFileName << endl;
+    }
+
+    if (ifi.is_open()){
+        
+        string line;
+        while(std::getline(ifi, line)){
+            vector<string> splits = pliib::split(line.c_str(), '\t');
+            tiny_faidx_entry_t* t = new tiny_faidx_entry_t(splits);
+            fai.add(t);
+        }
+    }
+    else{
+        cerr << "Couldn't open index " << ifn << "." << endl;
+    }
+    delete ifn;
+};
+
+inline void getSequence( const tiny_faidx_t& fai, const char* seqname, char*& seq){
+    uint32_t sz = 0;
+    
+    tiny_faidx_entry_t* entry;
+    if (fai.hasSeqID(seqname)){
+        fai.get(seqname, entry);
+        sz = entry->seq_len + 1;
+        seq = new char[sz];
+        seq[sz - 1] = '\0';
+        fseek64(fai.fasta, entry->offset, SEEK_SET);
+        if (fread(seq, sizeof(char), entry->seq_len, fai.fasta)){
+            pliib::remove_nulls_and_whitespace(seq, entry->seq_len);
+        }
+    }
+    else{
+        cerr << "No sequence found for ID: " << seqname << "." << endl;
+    }
+
+};
+
+inline void getSequence( const tiny_faidx_t& fai, const char* seqname,
+                         char*& seq, int start, int end){
+    getSequence(fai, seqname, seq);
+    end = min(end, (int) strlen(seq));
+    start = max(0, (int) start);
+    char* ret = new char[end - start + 1];
+    ret[end - start] = '\0';
+    memcpy(ret, seq + start, (end - start) * sizeof(char) );
+    delete seq;
+    seq = ret;
+};
+
+}
+
+#endif


### PR DESCRIPTION
This brings a new command, `fillseq`, that can replace the `*` placeholders in S lines with sequences in a FASTA file. It has to bring in a small FASTA parser to do this, but it should affect the build much.