### PR TITLE
Remove broken path_elem constructor

### DIFF
--- a/src/gfakluge.hpp
+++ b/src/gfakluge.hpp
@@ -153,13 +153,6 @@ namespace gfak{
         std::vector<bool> orientations;
         std::vector<std::string> overlaps;
         std::map<std::string, opt_elem> opt_fields;
-        path_elem(){
-            std::string name = "";
-            std::vector<std::string> segment_names;
-            std::vector<bool> orientations;
-            std::vector<std::string> overlaps;
-            std::map<std::string, opt_elem> opt_fields;
-        }
 
         /**
          *  Adds a GFA 0.1-style path_element (a "Walk") to a


### PR DESCRIPTION
Hi Eric, just going through the code I noticed the odd `path_elem()` constructor in `gfakluge.hpp`.

It looks like its intent was to initialise the struct members, but this isn't what it does. Instead it effectively creates five local objects that go out of scope right away, while doing no initialisation.

Since the struct needs no initialisation, this constructor can go away without harm - and with the benefit of faster default construction.