### PR TITLE
Add sensible default for gfak ids --start-ids

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -650,7 +650,7 @@ int convert_main(int argc, char** argv){
 int ids_main(int argc, char** argv){
     vector<string> g_files;
     bool block_order = false;
-    string start_string;
+    string start_string = "0:0:0:0:0";
     double spec = 0.0;
 
     if (argc == 1){


### PR DESCRIPTION
There is no check that the user has supplied `gfak ids --start-ids`, but without it `gfak` crashes with an uncaught exception (invalid input to `strtoul()`). I'm not intimately familiar with the GFA spec, but I assume that start IDs of zero are appropriate for all five fields?

Otherwise, we would need to a "you didn't give --start-ids/-s" warning to `ids_main()` after arg parsing.

Best,
kevin